### PR TITLE
feat: Support MCP Apps (SEP-1865) extension alongside OpenAI Apps SDK

### DIFF
--- a/fastapps/__init__.py
+++ b/fastapps/__init__.py
@@ -21,6 +21,7 @@ from .builder.compiler import WidgetBuilder, WidgetBuildResult
 from .core.protocol import ProtocolAdapter
 from .core.adapters.openai_apps import OpenAIAppsAdapter
 from .core.adapters.mcp_apps import MCPAppsAdapter
+from .core.adapters.auto import AutoProtocolAdapter
 from .core.server import WidgetMCPServer
 from .core.widget import BaseWidget, ClientContext, UserContext
 from .types.schema import ConfigDict, Field
@@ -51,6 +52,7 @@ __all__ = [
     "ProtocolAdapter",
     "OpenAIAppsAdapter",
     "MCPAppsAdapter",
+    "AutoProtocolAdapter",
     "WidgetBuilder",
     "WidgetBuildResult",
     "Field",

--- a/fastapps/__init__.py
+++ b/fastapps/__init__.py
@@ -18,6 +18,9 @@ Example:
 __author__ = "FastApps Team"
 
 from .builder.compiler import WidgetBuilder, WidgetBuildResult
+from .core.protocol import ProtocolAdapter
+from .core.adapters.openai_apps import OpenAIAppsAdapter
+from .core.adapters.mcp_apps import MCPAppsAdapter
 from .core.server import WidgetMCPServer
 from .core.widget import BaseWidget, ClientContext, UserContext
 from .types.schema import ConfigDict, Field
@@ -45,6 +48,9 @@ __all__ = [
     "ClientContext",
     "UserContext",
     "WidgetMCPServer",
+    "ProtocolAdapter",
+    "OpenAIAppsAdapter",
+    "MCPAppsAdapter",
     "WidgetBuilder",
     "WidgetBuildResult",
     "Field",

--- a/fastapps/cli/commands/dev.py
+++ b/fastapps/cli/commands/dev.py
@@ -157,13 +157,14 @@ def start_asset_server(assets_dir: Path, port: int = 4444):
         httpd.serve_forever()
 
 
-def start_dev_server(port=8001, host="0.0.0.0", mode="hosted"):
+def start_dev_server(port=8001, host="0.0.0.0", mode="hosted", protocol="openai-apps"):
     """Start development server with Cloudflare Tunnel.
 
     Args:
         port: Port for MCP server (default: 8001)
         host: Host to bind server (default: "0.0.0.0")
         mode: Build mode - "hosted" (default) or "inline"
+        protocol: UI protocol adapter ("openai-apps" | "mcp-apps")
     """
 
     # Check if we're in a FastApps project
@@ -221,7 +222,7 @@ def start_dev_server(port=8001, host="0.0.0.0", mode="hosted"):
         sys.path.insert(0, str(Path.cwd()))
         # Reset sys.argv to avoid argparse conflicts in server/main.py
         # Pass mode to server for builder
-        sys.argv = ["server/main.py", "--build", f"--mode={mode}"]
+        sys.argv = ["server/main.py", "--build", f"--mode={mode}", f"--protocol={protocol}"]
         from server.main import app
 
         # Create server config

--- a/fastapps/cli/commands/init.py
+++ b/fastapps/cli/commands/init.py
@@ -25,7 +25,14 @@ from typing import Dict
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Import FastApps framework
-from fastapps import WidgetBuilder, WidgetMCPServer, BaseWidget, WidgetBuildResult
+from fastapps import (
+    WidgetBuilder,
+    WidgetMCPServer,
+    BaseWidget,
+    WidgetBuildResult,
+    OpenAIAppsAdapter,
+    MCPAppsAdapter,
+)
 import uvicorn
 
 PROJECT_ROOT = Path(__file__).parent.parent
@@ -77,6 +84,12 @@ parser.add_argument(
     default="hosted",
     help="Widget build mode: hosted (default) or inline"
 )
+parser.add_argument(
+    "--protocol",
+    choices=["openai-apps", "mcp-apps"],
+    default="openai-apps",
+    help="UI protocol adapter: OpenAI Apps SDK (default) or MCP Apps extension"
+)
 args = parser.parse_args()
 
 # Load build results
@@ -109,10 +122,16 @@ def load_csp_config():
 
 csp_config = load_csp_config()
 
+def select_adapter(protocol: str):
+    if protocol == "mcp-apps":
+        return MCPAppsAdapter()
+    return OpenAIAppsAdapter()
+
 # Create MCP server with CSP configuration
 server = WidgetMCPServer(
     name="my-widgets",
     widgets=tools,
+    adapter=select_adapter(args.protocol),
     global_resource_domains=csp_config.get("resource_domains", []),
     global_connect_domains=csp_config.get("connect_domains", []),
 )

--- a/fastapps/cli/commands/init.py
+++ b/fastapps/cli/commands/init.py
@@ -32,6 +32,7 @@ from fastapps import (
     WidgetBuildResult,
     OpenAIAppsAdapter,
     MCPAppsAdapter,
+    AutoProtocolAdapter,
 )
 import uvicorn
 
@@ -86,7 +87,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--protocol",
-    choices=["openai-apps", "mcp-apps"],
+    choices=["openai-apps", "mcp-apps", "auto"],
     default="openai-apps",
     help="UI protocol adapter: OpenAI Apps SDK (default) or MCP Apps extension"
 )
@@ -125,6 +126,8 @@ csp_config = load_csp_config()
 def select_adapter(protocol: str):
     if protocol == "mcp-apps":
         return MCPAppsAdapter()
+    if protocol == "auto":
+        return AutoProtocolAdapter()
     return OpenAIAppsAdapter()
 
 # Create MCP server with CSP configuration

--- a/fastapps/cli/main.py
+++ b/fastapps/cli/main.py
@@ -113,7 +113,13 @@ def create(widget_name, auth, public, optional_auth, scopes, template):
     default='hosted',
     help="Widget build mode: 'hosted' (default, external JS/CSS on port 4444) or 'inline' (self-contained HTML)"
 )
-def dev(port, host, mode):
+@click.option(
+    "--protocol",
+    type=click.Choice(['openai-apps', 'mcp-apps'], case_sensitive=False),
+    default='openai-apps',
+    help="UI protocol adapter: OpenAI Apps SDK (default) or MCP Apps extension",
+)
+def dev(port, host, mode, protocol):
     """Start development server with Cloudflare Tunnel.
 
     This command will:
@@ -134,7 +140,7 @@ def dev(port, host, mode):
 
     Note: Uses Cloudflare Tunnel (free, unlimited, no sign-up required)
     """
-    start_dev_server(port=port, host=host, mode=mode)
+    start_dev_server(port=port, host=host, mode=mode, protocol=protocol)
 
 
 @cli.command()

--- a/fastapps/cli/main.py
+++ b/fastapps/cli/main.py
@@ -115,7 +115,7 @@ def create(widget_name, auth, public, optional_auth, scopes, template):
 )
 @click.option(
     "--protocol",
-    type=click.Choice(['openai-apps', 'mcp-apps'], case_sensitive=False),
+    type=click.Choice(['openai-apps', 'mcp-apps', 'auto'], case_sensitive=False),
     default='openai-apps',
     help="UI protocol adapter: OpenAI Apps SDK (default) or MCP Apps extension",
 )

--- a/fastapps/core/adapters/auto.py
+++ b/fastapps/core/adapters/auto.py
@@ -1,5 +1,7 @@
 """Auto-select protocol adapter based on host capabilities."""
 
+import logging
+
 from __future__ import annotations
 
 from typing import Optional, TYPE_CHECKING
@@ -10,6 +12,9 @@ from fastapps.core.protocol import ProtocolAdapter
 from fastapps.core.adapters.openai_apps import OpenAIAppsAdapter
 from fastapps.core.adapters.mcp_apps import MCPAppsAdapter
 from fastapps.core.adapters.utils import _inject_protocol_hint  # type: ignore[attr-defined]
+
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from fastapps.core.server import WidgetMCPServer
@@ -75,9 +80,9 @@ class AutoProtocolAdapter(ProtocolAdapter):
             ui_ext = extensions.get("io.modelcontextprotocol/ui")
             mime_types = ui_ext.get("mimeTypes", []) if isinstance(ui_ext, dict) else []
             if any(mt.lower() == "text/html+mcp" for mt in mime_types):
-                print("[AutoAdapter] Selected MCP Apps based on client capabilities")
+                logger.info("AutoAdapter selected MCP Apps based on client capabilities")
                 return self.mcp_adapter
         except Exception:
             pass
-        print("[AutoAdapter] Selected OpenAI Apps (default)")
+        logger.info("AutoAdapter selected OpenAI Apps (default)")
         return self.openai_adapter

--- a/fastapps/core/adapters/auto.py
+++ b/fastapps/core/adapters/auto.py
@@ -1,8 +1,8 @@
 """Auto-select protocol adapter based on host capabilities."""
 
-import logging
-
 from __future__ import annotations
+
+import logging
 
 from typing import Optional, TYPE_CHECKING
 

--- a/fastapps/core/adapters/auto.py
+++ b/fastapps/core/adapters/auto.py
@@ -9,6 +9,7 @@ from mcp import types
 from fastapps.core.protocol import ProtocolAdapter
 from fastapps.core.adapters.openai_apps import OpenAIAppsAdapter
 from fastapps.core.adapters.mcp_apps import MCPAppsAdapter
+from fastapps.core.adapters.utils import _inject_protocol_hint  # type: ignore[attr-defined]
 
 if TYPE_CHECKING:
     from fastapps.core.server import WidgetMCPServer

--- a/fastapps/core/adapters/auto.py
+++ b/fastapps/core/adapters/auto.py
@@ -75,7 +75,9 @@ class AutoProtocolAdapter(ProtocolAdapter):
             ui_ext = extensions.get("io.modelcontextprotocol/ui")
             mime_types = ui_ext.get("mimeTypes", []) if isinstance(ui_ext, dict) else []
             if any(mt.lower() == "text/html+mcp" for mt in mime_types):
+                print("[AutoAdapter] Selected MCP Apps based on client capabilities")
                 return self.mcp_adapter
         except Exception:
             pass
+        print("[AutoAdapter] Selected OpenAI Apps (default)")
         return self.openai_adapter

--- a/fastapps/core/adapters/auto.py
+++ b/fastapps/core/adapters/auto.py
@@ -1,0 +1,80 @@
+"""Auto-select protocol adapter based on host capabilities."""
+
+from __future__ import annotations
+
+from typing import Optional, TYPE_CHECKING
+
+from mcp import types
+
+from fastapps.core.protocol import ProtocolAdapter
+from fastapps.core.adapters.openai_apps import OpenAIAppsAdapter
+from fastapps.core.adapters.mcp_apps import MCPAppsAdapter
+
+if TYPE_CHECKING:
+    from fastapps.core.server import WidgetMCPServer
+
+
+class AutoProtocolAdapter(ProtocolAdapter):
+    """
+    Chooses OpenAI Apps or MCP Apps at runtime based on host capabilities.
+
+    Logic:
+    - Pre-register OpenAI handlers (baseline).
+    - On initialize, inspect client capabilities.extensions["io.modelcontextprotocol/ui"].
+    - If host advertises MCP Apps + supports text/html+mcp, switch to MCP handlers.
+    - Keep chosen adapter for the rest of the session.
+    """
+
+    def __init__(self):
+        self.active: Optional[ProtocolAdapter] = None
+        self.openai_adapter = OpenAIAppsAdapter()
+        self.mcp_adapter = MCPAppsAdapter()
+
+    def register_handlers(self, widget_server: "WidgetMCPServer") -> None:
+        # Start with OpenAI handlers as baseline
+        self.openai_adapter.register_handlers(widget_server)
+        self.active = self.openai_adapter
+
+        server = widget_server.mcp._mcp_server
+        original_initialize = server.request_handlers.get(types.InitializeRequest)
+
+        async def initialize_handler(
+            req: types.InitializeRequest,
+        ) -> types.ServerResult:
+            chosen = self._decide_adapter(req)
+            if chosen is self.mcp_adapter and self.active is not self.mcp_adapter:
+                # Switch to MCP handlers (overwrites request_handlers)
+                self.mcp_adapter.register_handlers(widget_server)
+                self.active = self.mcp_adapter
+
+            # After potential switch, get the current initialize handler
+            handler = server.request_handlers.get(types.InitializeRequest)
+            if handler is initialize_handler and original_initialize:
+                # Fallback to original if overwrite failed
+                handler = original_initialize
+
+            if handler:
+                return await handler(req)
+
+            # Should not happen, but fall back to minimal response
+            return types.ServerResult(
+                types.InitializeResult(
+                    protocolVersion=req.params.protocolVersion,
+                    capabilities=types.ServerCapabilities(),
+                    serverInfo=types.Implementation(name="FastApps", version="auto"),
+                )
+            )
+
+        server.request_handlers[types.InitializeRequest] = initialize_handler
+
+    def _decide_adapter(self, req: types.InitializeRequest) -> ProtocolAdapter:
+        try:
+            caps = getattr(req.params, "capabilities", None)
+            extensions = getattr(caps, "extensions", {}) if caps else {}
+            ui_ext = extensions.get("io.modelcontextprotocol/ui")
+            mime_types = ui_ext.get("mimeTypes", []) if isinstance(ui_ext, dict) else []
+            if any(mt.lower() == "text/html+mcp" for mt in mime_types):
+                return self.mcp_adapter
+        except Exception:
+            pass
+        return self.openai_adapter

--- a/fastapps/core/adapters/mcp_apps.py
+++ b/fastapps/core/adapters/mcp_apps.py
@@ -8,7 +8,7 @@ from mcp import types
 
 from fastapps.core.protocol import ProtocolAdapter
 from fastapps.core.utils import get_cli_version
-from fastapps.core.adapters.utils import _inject_protocol_hint
+from fastapps.core.adapters.utils import _execute_widget_call, _inject_protocol_hint
 from fastapps.core.widget import BaseWidget, ClientContext, UserContext
 
 if TYPE_CHECKING:
@@ -121,93 +121,16 @@ class MCPAppsAdapter(ProtocolAdapter):
 
         async def call_tool_handler(req: types.CallToolRequest) -> types.ServerResult:
             widget = widget_server.widgets_by_id.get(req.params.name)
-            if not widget:
-                return types.ServerResult(
-                    types.CallToolResult(
-                        content=[
-                            types.TextContent(
-                                type="text", text=f"Unknown tool: {req.params.name}"
-                            )
-                        ],
-                        isError=True,
-                    )
-                )
+            result = await _execute_widget_call(widget_server, widget, req)
 
-            try:
-                access_token = None
-                if hasattr(req, "context") and hasattr(req.context, "access_token"):
-                    access_token = req.context.access_token
-                elif hasattr(req.params, "_meta"):
-                    meta_token = req.params._meta.get("access_token")
-                    if meta_token:
-                        access_token = meta_token
-
-                widget_requires_auth = getattr(widget, "_auth_required", None)
-
-                if widget_requires_auth is None and widget_server.server_requires_auth:
-                    widget_requires_auth = True
-
-                if widget_requires_auth is True and not access_token:
-                    return types.ServerResult(
-                        types.CallToolResult(
-                            content=[
-                                types.TextContent(
-                                    type="text",
-                                    text="Authentication required for this tool",
-                                )
-                            ],
-                            isError=True,
-                        )
-                    )
-
-                if (
-                    access_token
-                    and hasattr(widget, "_auth_scopes")
-                    and widget._auth_scopes
-                ):
-                    user_scopes = getattr(access_token, "scopes", [])
-                    missing_scopes = set(widget._auth_scopes) - set(user_scopes)
-
-                    if missing_scopes:
-                        return types.ServerResult(
-                            types.CallToolResult(
-                                content=[
-                                    types.TextContent(
-                                        type="text",
-                                        text=f"Missing required scopes: {', '.join(missing_scopes)}",
-                                    )
-                                ],
-                                isError=True,
-                            )
-                        )
-
-                arguments = req.params.arguments or {}
-                input_data = widget.input_schema.model_validate(arguments)
-
-                meta = req.params._meta if hasattr(req.params, "_meta") else {}
-                requested_locale = meta.get("openai/locale") or meta.get("webplus/i18n")
-                if requested_locale:
-                    widget.resolved_locale = widget.negotiate_locale(requested_locale)
-
-                context = ClientContext(meta)
-                user = UserContext(access_token)
-
-                result_data = await widget.execute(input_data, context, user)
-            except Exception as exc:
-                return types.ServerResult(
-                    types.CallToolResult(
-                        content=[
-                            types.TextContent(type="text", text=f"Error: {str(exc)}")
-                        ],
-                        isError=True,
-                    )
-                )
+            if isinstance(result, types.ServerResult):
+                return result
 
             # MCP Apps relies on host rendering the referenced UI resource.
             return types.ServerResult(
                 types.CallToolResult(
                     content=[types.TextContent(type="text", text=widget.invoked)],
-                    structuredContent=result_data,
+                    structuredContent=result,
                 )
             )
 

--- a/fastapps/core/adapters/mcp_apps.py
+++ b/fastapps/core/adapters/mcp_apps.py
@@ -8,6 +8,7 @@ from mcp import types
 
 from fastapps.core.protocol import ProtocolAdapter
 from fastapps.core.utils import get_cli_version
+from fastapps.core.adapters.utils import _inject_protocol_hint
 from fastapps.core.widget import BaseWidget, ClientContext, UserContext
 
 if TYPE_CHECKING:
@@ -106,11 +107,13 @@ class MCPAppsAdapter(ProtocolAdapter):
                     )
                 )
 
+            html = _inject_protocol_hint(widget.build_result.html, "mcp-apps")
+
             contents = [
                 types.TextResourceContents(
                     uri=widget.template_uri,
                     mimeType="text/html+mcp",
-                    text=widget.build_result.html,
+                    text=html,
                     _meta=self._build_ui_meta(widget),
                 )
             ]

--- a/fastapps/core/adapters/mcp_apps.py
+++ b/fastapps/core/adapters/mcp_apps.py
@@ -1,0 +1,247 @@
+"""Adapter for MCP Apps Extension (SEP-1865 draft)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from mcp import types
+
+from fastapps.core.protocol import ProtocolAdapter
+from fastapps.core.utils import get_cli_version
+from fastapps.core.widget import BaseWidget, ClientContext, UserContext
+
+if TYPE_CHECKING:
+    from fastapps.core.server import WidgetMCPServer
+
+
+class MCPAppsAdapter(ProtocolAdapter):
+    """
+    Implements handler wiring for the MCP Apps extension (ui:// resources, text/html+mcp).
+
+    References:
+    - reference/ext-apps/specification/draft/apps.mdx
+    """
+
+    def register_handlers(self, widget_server: "WidgetMCPServer") -> None:
+        server = widget_server.mcp._mcp_server
+
+        original_initialize = server.request_handlers.get(types.InitializeRequest)
+
+        async def initialize_handler(
+            req: types.InitializeRequest,
+        ) -> types.ServerResult:
+            # MCP Apps uses ui/initialize between host <-> iframe.
+            # Here we just mirror locale negotiation for consistency.
+            meta = req.params._meta if hasattr(req.params, "_meta") else {}
+            requested_locale = meta.get("openai/locale") or meta.get("webplus/i18n")
+
+            if requested_locale:
+                widget_server.client_locale = requested_locale
+                for widget in widget_server.widgets_by_id.values():
+                    resolved = widget.negotiate_locale(requested_locale)
+                    widget.resolved_locale = resolved
+
+            if original_initialize:
+                return await original_initialize(req)
+
+            capabilities = types.ServerCapabilities()
+            # Advertise MCP Apps extension if supported by the types model
+            try:
+                setattr(capabilities, "extensions", {"io.modelcontextprotocol/ui": {}})
+            except Exception:
+                pass
+
+            return types.ServerResult(
+                types.InitializeResult(
+                    protocolVersion=req.params.protocolVersion,
+                    capabilities=capabilities,
+                    serverInfo=types.Implementation(
+                        name="FastApps", version=get_cli_version()
+                    ),
+                )
+            )
+
+        server.request_handlers[types.InitializeRequest] = initialize_handler
+
+        @server.list_tools()
+        async def list_tools_handler() -> List[types.Tool]:
+            tools_list = []
+            for w in widget_server.widgets_by_id.values():
+                tool_meta = {
+                    "ui/resourceUri": w.template_uri,
+                }
+
+                if "securitySchemes" not in tool_meta and widget_server.server_requires_auth:
+                    tool_meta["securitySchemes"] = [
+                        {"type": "oauth2", "scopes": widget_server.server_auth_scopes}
+                    ]
+
+                tools_list.append(
+                    types.Tool(
+                        name=w.identifier,
+                        title=w.title,
+                        description=w.description or w.title,
+                        inputSchema=w.get_input_schema(),
+                        _meta=tool_meta,
+                    )
+                )
+            return tools_list
+
+        @server.list_resources()
+        async def list_resources_handler() -> List[types.Resource]:
+            resources = []
+            for w in widget_server.widgets_by_id.values():
+                resources.append(self._build_ui_resource(w))
+            return resources
+
+        async def read_resource_handler(
+            req: types.ReadResourceRequest,
+        ) -> types.ServerResult:
+            widget = widget_server.widgets_by_uri.get(str(req.params.uri))
+            if not widget:
+                return types.ServerResult(
+                    types.ReadResourceResult(
+                        contents=[],
+                        _meta={"error": f"Unknown resource: {req.params.uri}"},
+                    )
+                )
+
+            contents = [
+                types.TextResourceContents(
+                    uri=widget.template_uri,
+                    mimeType="text/html+mcp",
+                    text=widget.build_result.html,
+                    _meta=self._build_ui_meta(widget),
+                )
+            ]
+            return types.ServerResult(types.ReadResourceResult(contents=contents))
+
+        async def call_tool_handler(req: types.CallToolRequest) -> types.ServerResult:
+            widget = widget_server.widgets_by_id.get(req.params.name)
+            if not widget:
+                return types.ServerResult(
+                    types.CallToolResult(
+                        content=[
+                            types.TextContent(
+                                type="text", text=f"Unknown tool: {req.params.name}"
+                            )
+                        ],
+                        isError=True,
+                    )
+                )
+
+            try:
+                access_token = None
+                if hasattr(req, "context") and hasattr(req.context, "access_token"):
+                    access_token = req.context.access_token
+                elif hasattr(req.params, "_meta"):
+                    meta_token = req.params._meta.get("access_token")
+                    if meta_token:
+                        access_token = meta_token
+
+                widget_requires_auth = getattr(widget, "_auth_required", None)
+
+                if widget_requires_auth is None and widget_server.server_requires_auth:
+                    widget_requires_auth = True
+
+                if widget_requires_auth is True and not access_token:
+                    return types.ServerResult(
+                        types.CallToolResult(
+                            content=[
+                                types.TextContent(
+                                    type="text",
+                                    text="Authentication required for this tool",
+                                )
+                            ],
+                            isError=True,
+                        )
+                    )
+
+                if (
+                    access_token
+                    and hasattr(widget, "_auth_scopes")
+                    and widget._auth_scopes
+                ):
+                    user_scopes = getattr(access_token, "scopes", [])
+                    missing_scopes = set(widget._auth_scopes) - set(user_scopes)
+
+                    if missing_scopes:
+                        return types.ServerResult(
+                            types.CallToolResult(
+                                content=[
+                                    types.TextContent(
+                                        type="text",
+                                        text=f"Missing required scopes: {', '.join(missing_scopes)}",
+                                    )
+                                ],
+                                isError=True,
+                            )
+                        )
+
+                arguments = req.params.arguments or {}
+                input_data = widget.input_schema.model_validate(arguments)
+
+                meta = req.params._meta if hasattr(req.params, "_meta") else {}
+                requested_locale = meta.get("openai/locale") or meta.get("webplus/i18n")
+                if requested_locale:
+                    widget.resolved_locale = widget.negotiate_locale(requested_locale)
+
+                context = ClientContext(meta)
+                user = UserContext(access_token)
+
+                result_data = await widget.execute(input_data, context, user)
+            except Exception as exc:
+                return types.ServerResult(
+                    types.CallToolResult(
+                        content=[
+                            types.TextContent(type="text", text=f"Error: {str(exc)}")
+                        ],
+                        isError=True,
+                    )
+                )
+
+            # MCP Apps relies on host rendering the referenced UI resource.
+            return types.ServerResult(
+                types.CallToolResult(
+                    content=[types.TextContent(type="text", text=widget.invoked)],
+                    structuredContent=result_data,
+                )
+            )
+
+        server.request_handlers[types.ReadResourceRequest] = read_resource_handler
+        server.request_handlers[types.CallToolRequest] = call_tool_handler
+
+    def _build_ui_resource(self, widget: BaseWidget) -> types.Resource:
+        """Create a Resource describing the UI for MCP Apps."""
+        return types.Resource(
+            name=widget.title,
+            title=widget.title,
+            uri=widget.template_uri,
+            description=f"{widget.title} widget markup",
+            mimeType="text/html+mcp",
+            _meta=self._build_ui_meta(widget),
+        )
+
+    def _build_ui_meta(self, widget: BaseWidget) -> Dict[str, Any]:
+        """Map widget CSP/domain preferences to MCP Apps meta."""
+        meta: Dict[str, Any] = {"ui": {}}
+        csp: Dict[str, Any] = {}
+
+        widget_csp = widget.widget_csp or {}
+        resource_domains = widget_csp.get("resource_domains") or []
+        connect_domains = widget_csp.get("connect_domains") or []
+
+        if connect_domains:
+            csp["connect_domains"] = connect_domains
+        if resource_domains:
+            csp["resource_domains"] = resource_domains
+
+        if csp:
+            meta["ui"]["csp"] = csp
+
+        if widget.widget_domain:
+            meta["ui"]["domain"] = widget.widget_domain
+        if widget.widget_prefers_border:
+            meta["ui"]["prefersBorder"] = True
+
+        return meta

--- a/fastapps/core/adapters/openai_apps.py
+++ b/fastapps/core/adapters/openai_apps.py
@@ -240,7 +240,7 @@ class OpenAIAppsAdapter(ProtocolAdapter):
 
     def _register_assets_proxy(self, widget_server: "WidgetMCPServer") -> None:
         """Proxy /assets requests to local asset server (same behavior as before)."""
-        app = widget_server.mcp._mcp_server.http_app
+        app = getattr(widget_server.mcp._mcp_server, "http_app", None)
         if app is None:
             app = widget_server.mcp.http_app()
 

--- a/fastapps/core/adapters/openai_apps.py
+++ b/fastapps/core/adapters/openai_apps.py
@@ -8,6 +8,7 @@ from mcp import types
 
 from fastapps.core.protocol import ProtocolAdapter
 from fastapps.core.utils import get_cli_version
+from fastapps.core.adapters.utils import _inject_protocol_hint
 from fastapps.core.widget import BaseWidget, ClientContext, UserContext
 
 if TYPE_CHECKING:
@@ -114,11 +115,13 @@ class OpenAIAppsAdapter(ProtocolAdapter):
                     )
                 )
 
+            html = _inject_protocol_hint(widget.build_result.html, "openai-apps")
+
             contents = [
                 types.TextResourceContents(
                     uri=widget.template_uri,
                     mimeType="text/html+skybridge",
-                    text=widget.build_result.html,
+                    text=html,
                     _meta=widget.get_resource_meta(),
                 )
             ]

--- a/fastapps/core/adapters/utils.py
+++ b/fastapps/core/adapters/utils.py
@@ -1,4 +1,13 @@
-"""Shared helper for protocol-specific HTML injections."""
+"""Shared helpers for protocol-specific behavior."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Union
+
+from mcp import types
+
+from fastapps.core.widget import BaseWidget, ClientContext, UserContext
+
 
 def _inject_protocol_hint(html: str, protocol: str) -> str:
     """
@@ -15,3 +24,76 @@ def _inject_protocol_hint(html: str, protocol: str) -> str:
     if "</head>" in html:
         return html.replace("</head>", f"{hint}</head>", 1)
     return hint + html
+
+
+def _error_call_tool(message: str) -> types.ServerResult:
+    """Create a standardized error response for call_tool failures."""
+    return types.ServerResult(
+        types.CallToolResult(
+            content=[types.TextContent(type="text", text=message)],
+            isError=True,
+        )
+    )
+
+
+async def _execute_widget_call(
+    widget_server: "WidgetMCPServer",
+    widget: Optional[BaseWidget],
+    req: types.CallToolRequest,
+) -> Union[types.ServerResult, Any]:
+    """
+    Shared call_tool execution pipeline:
+    - Lookup widget
+    - Auth inheritance + scope checks
+    - Input validation
+    - Locale negotiation
+    - Context construction
+    - Widget execution
+
+    Returns:
+        - types.ServerResult on error, or
+        - widget.execute(...) result on success
+    """
+    if not widget:
+        return _error_call_tool(f"Unknown tool: {req.params.name}")
+
+    try:
+        access_token = None
+        if hasattr(req, "context") and hasattr(req.context, "access_token"):
+            access_token = req.context.access_token
+        elif hasattr(req.params, "_meta"):
+            meta_token = req.params._meta.get("access_token")
+            if meta_token:
+                access_token = meta_token
+
+        widget_requires_auth = getattr(widget, "_auth_required", None)
+
+        if widget_requires_auth is None and widget_server.server_requires_auth:
+            widget_requires_auth = True
+
+        if widget_requires_auth is True and not access_token:
+            return _error_call_tool("Authentication required for this tool")
+
+        if access_token and hasattr(widget, "_auth_scopes") and widget._auth_scopes:
+            user_scopes = getattr(access_token, "scopes", [])
+            missing_scopes = set(widget._auth_scopes) - set(user_scopes)
+
+            if missing_scopes:
+                return _error_call_tool(
+                    f"Missing required scopes: {', '.join(missing_scopes)}"
+                )
+
+        arguments = req.params.arguments or {}
+        input_data = widget.input_schema.model_validate(arguments)
+
+        meta = req.params._meta if hasattr(req.params, "_meta") else {}
+        requested_locale = meta.get("openai/locale") or meta.get("webplus/i18n")
+        if requested_locale:
+            widget.resolved_locale = widget.negotiate_locale(requested_locale)
+
+        context = ClientContext(meta)
+        user = UserContext(access_token)
+
+        return await widget.execute(input_data, context, user)
+    except Exception as exc:
+        return _error_call_tool(f"Error: {str(exc)}")

--- a/fastapps/core/adapters/utils.py
+++ b/fastapps/core/adapters/utils.py
@@ -1,0 +1,17 @@
+"""Shared helper for protocol-specific HTML injections."""
+
+def _inject_protocol_hint(html: str, protocol: str) -> str:
+    """
+    Inject a small script that exposes the chosen protocol to the UI runtime.
+
+    Args:
+        html: Original HTML string
+        protocol: One of "openai-apps" or "mcp-apps"
+
+    Returns:
+        HTML string with protocol hint injected before </head> or at top.
+    """
+    hint = f'<script>window.__FASTAPPS_PROTOCOL="{protocol}";</script>'
+    if "</head>" in html:
+        return html.replace("</head>", f"{hint}</head>", 1)
+    return hint + html

--- a/fastapps/core/protocol.py
+++ b/fastapps/core/protocol.py
@@ -1,0 +1,24 @@
+"""Protocol adapter interface for MCP UI variants.
+
+Adapters allow the framework to target different MCP UI extensions
+without rewriting widget or server code. The default behavior remains
+OpenAI Apps SDK compatible; other adapters can register their own
+handlers on the server instance.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fastapps.core.server import WidgetMCPServer
+
+
+class ProtocolAdapter(ABC):
+    """Defines how a protocol variation wires MCP handlers."""
+
+    @abstractmethod
+    def register_handlers(self, widget_server: "WidgetMCPServer") -> None:
+        """Attach protocol-specific handlers to the given server."""
+        raise NotImplementedError

--- a/fastapps/templates/albums/widget/index.jsx
+++ b/fastapps/templates/albums/widget/index.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { AppsSDKUIProvider } from "@openai/apps-sdk-ui/components/AppsSDKUIProvider";
 import { Button } from "@openai/apps-sdk-ui/components/Button";
 import { EmptyMessage } from "@openai/apps-sdk-ui/components/EmptyMessage";
-import { useWidgetData, useHostContextCompat } from "fastapps";
+import { useWidgetData, useHostContextCompat, useHostActions } from "fastapps";
 import useEmblaCarousel from "embla-carousel-react";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import FullscreenViewer from "./FullscreenViewer";
@@ -111,6 +111,7 @@ function {ClassName}Inner() {
   const isFullscreen = hostContext.displayMode === "fullscreen";
   const [selectedAlbum, setSelectedAlbum] = React.useState(null);
   const maxHeight = hostContext.maxHeight ?? undefined;
+  const hostActions = useHostActions();
 
   React.useEffect(() => {
     if (!selectedAlbum) {
@@ -120,19 +121,19 @@ function {ClassName}Inner() {
     if (!stillExists) {
       setSelectedAlbum(null);
       // Graceful no-op if not supported
-      window?.openai?.requestDisplayMode?.({ mode: "inline" });
+      hostActions.requestDisplayMode("inline");
     }
-  }, [limitedAlbums, selectedAlbum]);
+  }, [hostActions, limitedAlbums, selectedAlbum]);
 
   const handleSelectAlbum = (album) => {
     if (!album) return;
     setSelectedAlbum(album);
-    window?.openai?.requestDisplayMode?.({ mode: "fullscreen" });
+    hostActions.requestDisplayMode("fullscreen");
   };
 
   const handleBackToAlbums = () => {
     setSelectedAlbum(null);
-    window?.openai?.requestDisplayMode?.({ mode: "inline" });
+    hostActions.requestDisplayMode("inline");
   };
 
   return (

--- a/fastapps/templates/albums/widget/index.jsx
+++ b/fastapps/templates/albums/widget/index.jsx
@@ -97,15 +97,15 @@ function AlbumsCarousel({ albums, onSelect }) {
 
 function {ClassName}Inner() {
   const data = useWidgetData() || {};
-  const { albums } = data;
-  const normalizedAlbums = Array.isArray(albums)
-    ? albums
-        .filter((album) => album && album.cover)
-        .map((album) => ({
-          ...album,
-          photos: Array.isArray(album.photos) ? album.photos : [],
-        }))
-    : [];
+  const albumsFromData = Array.isArray(data.albums) ? data.albums : [];
+
+  const normalizedAlbums = albumsFromData
+    .filter((album) => album && album.cover)
+    .map((album) => ({
+      ...album,
+      photos: Array.isArray(album.photos) ? album.photos : [],
+    }));
+
   const limitedAlbums = normalizedAlbums.slice(0, 8);
   const hostContext = useHostContextCompat();
   const isFullscreen = hostContext.displayMode === "fullscreen";

--- a/fastapps/templates/albums/widget/index.jsx
+++ b/fastapps/templates/albums/widget/index.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { AppsSDKUIProvider } from "@openai/apps-sdk-ui/components/AppsSDKUIProvider";
 import { Button } from "@openai/apps-sdk-ui/components/Button";
 import { EmptyMessage } from "@openai/apps-sdk-ui/components/EmptyMessage";
-import { useWidgetProps, useOpenAiGlobal, useMaxHeight } from "fastapps";
+import { useWidgetData, useHostContextCompat } from "fastapps";
 import useEmblaCarousel from "embla-carousel-react";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import FullscreenViewer from "./FullscreenViewer";
@@ -96,7 +96,8 @@ function AlbumsCarousel({ albums, onSelect }) {
 }
 
 function {ClassName}Inner() {
-  const { albums } = useWidgetProps() || {};
+  const data = useWidgetData() || {};
+  const { albums } = data;
   const normalizedAlbums = Array.isArray(albums)
     ? albums
         .filter((album) => album && album.cover)
@@ -106,10 +107,10 @@ function {ClassName}Inner() {
         }))
     : [];
   const limitedAlbums = normalizedAlbums.slice(0, 8);
-  const displayMode = useOpenAiGlobal("displayMode");
-  const isFullscreen = displayMode === "fullscreen";
+  const hostContext = useHostContextCompat();
+  const isFullscreen = hostContext.displayMode === "fullscreen";
   const [selectedAlbum, setSelectedAlbum] = React.useState(null);
-  const maxHeight = useMaxHeight() ?? undefined;
+  const maxHeight = hostContext.maxHeight ?? undefined;
 
   React.useEffect(() => {
     if (!selectedAlbum) {
@@ -118,25 +119,20 @@ function {ClassName}Inner() {
     const stillExists = limitedAlbums.some((album) => album.id === selectedAlbum.id);
     if (!stillExists) {
       setSelectedAlbum(null);
-      if (window?.openai?.requestDisplayMode) {
-        window.openai.requestDisplayMode({ mode: "inline" });
-      }
+      // Graceful no-op if not supported
+      window?.openai?.requestDisplayMode?.({ mode: "inline" });
     }
   }, [limitedAlbums, selectedAlbum]);
 
   const handleSelectAlbum = (album) => {
     if (!album) return;
     setSelectedAlbum(album);
-    if (window?.openai?.requestDisplayMode) {
-      window.openai.requestDisplayMode({ mode: "fullscreen" });
-    }
+    window?.openai?.requestDisplayMode?.({ mode: "fullscreen" });
   };
 
   const handleBackToAlbums = () => {
     setSelectedAlbum(null);
-    if (window?.openai?.requestDisplayMode) {
-      window.openai.requestDisplayMode({ mode: "inline" });
-    }
+    window?.openai?.requestDisplayMode?.({ mode: "inline" });
   };
 
   return (

--- a/fastapps/templates/carousel/widget/index.jsx
+++ b/fastapps/templates/carousel/widget/index.jsx
@@ -2,14 +2,15 @@ import React from "react";
 import { AppsSDKUIProvider } from "@openai/apps-sdk-ui/components/AppsSDKUIProvider";
 import { Button } from "@openai/apps-sdk-ui/components/Button";
 import { EmptyMessage } from "@openai/apps-sdk-ui/components/EmptyMessage";
-import { useWidgetProps } from "fastapps";
+import { useWidgetData } from "fastapps";
 import useEmblaCarousel from "embla-carousel-react";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import Card from "./Card";
 import "./index.css";
 
 function {ClassName}Inner() {
-  const { cards } = useWidgetProps() || {};
+  const data = useWidgetData() || {};
+  const { cards } = data;
 
   const normalizedCards = Array.isArray(cards) ? cards : [];
   const limitedCards = normalizedCards.slice(0, 8);

--- a/fastapps/templates/default/widget/index.jsx
+++ b/fastapps/templates/default/widget/index.jsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { AppsSDKUIProvider } from "@openai/apps-sdk-ui/components/AppsSDKUIProvider";
 import { Badge } from "@openai/apps-sdk-ui/components/Badge";
-import { useWidgetProps } from "fastapps";
+import { useWidgetData } from "fastapps";
 
 function {ClassName}Inner() {
-  const { message } = useWidgetProps() || {};
+  const data = useWidgetData() || {};
+  const { message } = data;
 
   return (
     <div className="w-full rounded-3xl border border-default bg-surface shadow-card p-6 sm:p-8 text-left">

--- a/fastapps/templates/list/widget/index.jsx
+++ b/fastapps/templates/list/widget/index.jsx
@@ -3,12 +3,13 @@ import { AppsSDKUIProvider } from "@openai/apps-sdk-ui/components/AppsSDKUIProvi
 import { Button } from "@openai/apps-sdk-ui/components/Button";
 import { EmptyMessage } from "@openai/apps-sdk-ui/components/EmptyMessage";
 import { Image } from "@openai/apps-sdk-ui/components/Image";
-import { useWidgetProps } from "fastapps";
+import { useWidgetData } from "fastapps";
 import { PlusCircle, Star } from "lucide-react";
 import "./index.css";
 
 function {ClassName}Inner() {
-  const { title, description, items } = useWidgetProps() || {};
+  const data = useWidgetData() || {};
+  const { title, description, items } = data;
   const normalizedItems = Array.isArray(items) ? items.slice(0, 7) : [];
   const hasItems = normalizedItems.length > 0;
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fastapps",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fastapps",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "bin": {
         "fastapps-build": "build-all.mts"

--- a/js/src/hooks/useDisplayMode.ts
+++ b/js/src/hooks/useDisplayMode.ts
@@ -1,4 +1,4 @@
-import { useOpenAiGlobal } from "./useOpenAiGlobal";
+import { useOpenAiGlobal } from "./useOpenaiGlobal";
 import { type DisplayMode } from "./types";
 
 /**
@@ -24,4 +24,3 @@ import { type DisplayMode } from "./types";
 export const useDisplayMode = (): DisplayMode | null => {
   return useOpenAiGlobal("displayMode");
 };
-

--- a/js/src/hooks/useHostActions.ts
+++ b/js/src/hooks/useHostActions.ts
@@ -1,0 +1,77 @@
+import { useCallback } from "react";
+import { McpAppsClient } from "../mcp/appsClient";
+
+/**
+ * Host actions compatible with both OpenAI Apps and MCP Apps.
+ *
+ * - openLink: OpenAI openExternal or MCP ui/open-link
+ * - sendMessage: OpenAI sendFollowUpMessage or MCP ui/message
+ * - callTool: OpenAI callTool or MCP tools/call
+ * - requestDisplayMode: OpenAI requestDisplayMode (no MCP equivalent yet)
+ */
+export function useHostActions(targetWindow?: Window) {
+  const clientRef = useCallback(() => new McpAppsClient(targetWindow), [targetWindow]);
+
+  const ensureMcpClient = useCallback(() => {
+    const client = clientRef();
+    client.connect();
+    client.initialize().catch(() => {
+      /* ignore init errors */
+    });
+    return client;
+  }, [clientRef]);
+
+  const openLink = useCallback(
+    async (href: string) => {
+      if (window?.openai?.openExternal) {
+        return window.openai.openExternal({ href });
+      }
+      const client = ensureMcpClient();
+      return client.sendRequest("ui/open-link", { url: href });
+    },
+    [ensureMcpClient]
+  );
+
+  const sendMessage = useCallback(
+    async (text: string) => {
+      if (window?.openai?.sendFollowUpMessage) {
+        return window.openai.sendFollowUpMessage({ prompt: text });
+      }
+      const client = ensureMcpClient();
+      return client.sendRequest("ui/message", {
+        role: "user",
+        content: { type: "text", text },
+      });
+    },
+    [ensureMcpClient]
+  );
+
+  const callTool = useCallback(
+    async (name: string, args: Record<string, unknown>) => {
+      if (window?.openai?.callTool) {
+        return window.openai.callTool(name, args);
+      }
+      const client = ensureMcpClient();
+      return client.sendRequest("tools/call", { name, arguments: args });
+    },
+    [ensureMcpClient]
+  );
+
+  const requestDisplayMode = useCallback(
+    async (mode: "inline" | "fullscreen" | "pip") => {
+      if (window?.openai?.requestDisplayMode) {
+        return window.openai.requestDisplayMode({ mode });
+      }
+      // No MCP Apps equivalent defined yet; return a resolved promise.
+      return Promise.resolve({ mode });
+    },
+    []
+  );
+
+  return {
+    openLink,
+    sendMessage,
+    callTool,
+    requestDisplayMode,
+  };
+}

--- a/js/src/hooks/useHostActions.ts
+++ b/js/src/hooks/useHostActions.ts
@@ -10,6 +10,10 @@ import { McpAppsClient } from "../mcp/appsClient";
  * - requestDisplayMode: OpenAI requestDisplayMode (no MCP equivalent yet)
  */
 export function useHostActions(targetWindow?: Window) {
+  const protocolHint =
+    typeof window !== "undefined"
+      ? (window as any).__FASTAPPS_PROTOCOL
+      : undefined;
   const clientRef = useCallback(() => new McpAppsClient(targetWindow), [targetWindow]);
 
   const ensureMcpClient = useCallback(() => {
@@ -23,7 +27,7 @@ export function useHostActions(targetWindow?: Window) {
 
   const openLink = useCallback(
     async (href: string) => {
-      if (window?.openai?.openExternal) {
+      if (protocolHint !== "mcp-apps" && window?.openai?.openExternal) {
         return window.openai.openExternal({ href });
       }
       const client = ensureMcpClient();
@@ -34,7 +38,7 @@ export function useHostActions(targetWindow?: Window) {
 
   const sendMessage = useCallback(
     async (text: string) => {
-      if (window?.openai?.sendFollowUpMessage) {
+      if (protocolHint !== "mcp-apps" && window?.openai?.sendFollowUpMessage) {
         return window.openai.sendFollowUpMessage({ prompt: text });
       }
       const client = ensureMcpClient();
@@ -48,7 +52,7 @@ export function useHostActions(targetWindow?: Window) {
 
   const callTool = useCallback(
     async (name: string, args: Record<string, unknown>) => {
-      if (window?.openai?.callTool) {
+      if (protocolHint !== "mcp-apps" && window?.openai?.callTool) {
         return window.openai.callTool(name, args);
       }
       const client = ensureMcpClient();
@@ -59,7 +63,7 @@ export function useHostActions(targetWindow?: Window) {
 
   const requestDisplayMode = useCallback(
     async (mode: "inline" | "fullscreen" | "pip") => {
-      if (window?.openai?.requestDisplayMode) {
+      if (protocolHint !== "mcp-apps" && window?.openai?.requestDisplayMode) {
         return window.openai.requestDisplayMode({ mode });
       }
       // No MCP Apps equivalent defined yet; return a resolved promise.

--- a/js/src/hooks/useHostContextCompat.ts
+++ b/js/src/hooks/useHostContextCompat.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useOpenAiGlobal } from "./useOpenAiGlobal";
+import { useOpenAiGlobal } from "./useOpenaiGlobal";
 import { useMcpAppsHostContext } from "./useMcpAppsHostContext";
 
 /**

--- a/js/src/hooks/useHostContextCompat.ts
+++ b/js/src/hooks/useHostContextCompat.ts
@@ -1,0 +1,48 @@
+import { useMemo } from "react";
+import { useOpenAiGlobal } from "./useOpenAiGlobal";
+import { useMcpAppsHostContext } from "./useMcpAppsHostContext";
+
+/**
+ * Merge OpenAI globals and MCP Apps hostContext into a single object.
+ * OpenAI values take precedence if present.
+ */
+export function useHostContextCompat() {
+  const openaiTheme = useOpenAiGlobal("theme");
+  const openaiDisplayMode = useOpenAiGlobal("displayMode");
+  const openaiMaxHeight = useOpenAiGlobal("maxHeight");
+  const openaiSafeArea = useOpenAiGlobal("safeArea");
+  const openaiLocale = useOpenAiGlobal("locale");
+  const openaiUserAgent = useOpenAiGlobal("userAgent");
+
+  const { hostContext } = useMcpAppsHostContext();
+
+  return useMemo(
+    () => ({
+      theme: openaiTheme ?? hostContext?.theme ?? null,
+      displayMode: openaiDisplayMode ?? hostContext?.displayMode ?? null,
+      maxHeight: openaiMaxHeight ?? hostContext?.viewport?.maxHeight ?? null,
+      safeArea: openaiSafeArea ?? hostContext?.safeAreaInsets ?? null,
+      locale: openaiLocale ?? hostContext?.locale ?? null,
+      userAgent: openaiUserAgent ?? hostContext?.userAgent ?? null,
+      // raw accessors
+      _openai: {
+        theme: openaiTheme,
+        displayMode: openaiDisplayMode,
+        maxHeight: openaiMaxHeight,
+        safeArea: openaiSafeArea,
+        locale: openaiLocale,
+        userAgent: openaiUserAgent,
+      },
+      _mcp: hostContext,
+    }),
+    [
+      openaiTheme,
+      openaiDisplayMode,
+      openaiMaxHeight,
+      openaiSafeArea,
+      openaiLocale,
+      openaiUserAgent,
+      hostContext,
+    ]
+  );
+}

--- a/js/src/hooks/useHostContextCompat.ts
+++ b/js/src/hooks/useHostContextCompat.ts
@@ -15,15 +15,49 @@ export function useHostContextCompat() {
   const openaiUserAgent = useOpenAiGlobal("userAgent");
 
   const { hostContext } = useMcpAppsHostContext();
+  const protocolHint =
+    typeof window !== "undefined"
+      ? (window as any).__FASTAPPS_PROTOCOL
+      : undefined;
 
   return useMemo(
     () => ({
-      theme: openaiTheme ?? hostContext?.theme ?? null,
-      displayMode: openaiDisplayMode ?? hostContext?.displayMode ?? null,
-      maxHeight: openaiMaxHeight ?? hostContext?.viewport?.maxHeight ?? null,
-      safeArea: openaiSafeArea ?? hostContext?.safeAreaInsets ?? null,
-      locale: openaiLocale ?? hostContext?.locale ?? null,
-      userAgent: openaiUserAgent ?? hostContext?.userAgent ?? null,
+      theme:
+        protocolHint === "openai-apps"
+          ? openaiTheme ?? null
+          : protocolHint === "mcp-apps"
+            ? hostContext?.theme ?? null
+            : openaiTheme ?? hostContext?.theme ?? null,
+      displayMode:
+        protocolHint === "openai-apps"
+          ? openaiDisplayMode ?? null
+          : protocolHint === "mcp-apps"
+            ? hostContext?.displayMode ?? null
+            : openaiDisplayMode ?? hostContext?.displayMode ?? null,
+      maxHeight:
+        protocolHint === "openai-apps"
+          ? openaiMaxHeight ?? null
+          : protocolHint === "mcp-apps"
+            ? hostContext?.viewport?.maxHeight ?? null
+            : openaiMaxHeight ?? hostContext?.viewport?.maxHeight ?? null,
+      safeArea:
+        protocolHint === "openai-apps"
+          ? openaiSafeArea ?? null
+          : protocolHint === "mcp-apps"
+            ? hostContext?.safeAreaInsets ?? null
+            : openaiSafeArea ?? hostContext?.safeAreaInsets ?? null,
+      locale:
+        protocolHint === "openai-apps"
+          ? openaiLocale ?? null
+          : protocolHint === "mcp-apps"
+            ? hostContext?.locale ?? null
+            : openaiLocale ?? hostContext?.locale ?? null,
+      userAgent:
+        protocolHint === "openai-apps"
+          ? openaiUserAgent ?? null
+          : protocolHint === "mcp-apps"
+            ? hostContext?.userAgent ?? null
+            : openaiUserAgent ?? hostContext?.userAgent ?? null,
       // raw accessors
       _openai: {
         theme: openaiTheme,
@@ -43,6 +77,7 @@ export function useHostContextCompat() {
       openaiLocale,
       openaiUserAgent,
       hostContext,
+      protocolHint,
     ]
   );
 }

--- a/js/src/hooks/useMaxHeight.ts
+++ b/js/src/hooks/useMaxHeight.ts
@@ -1,4 +1,4 @@
-import { useOpenAiGlobal } from "./useOpenAiGlobal";
+import { useOpenAiGlobal } from "./useOpenaiGlobal";
 
 /**
  * Hook to access the maximum height constraint from ChatGPT.
@@ -23,4 +23,3 @@ import { useOpenAiGlobal } from "./useOpenAiGlobal";
 export const useMaxHeight = (): number | null => {
   return useOpenAiGlobal("maxHeight");
 };
-

--- a/js/src/hooks/useMcpAppsHostContext.ts
+++ b/js/src/hooks/useMcpAppsHostContext.ts
@@ -8,7 +8,10 @@ import { HostContext, McpAppsClient } from "../mcp/appsClient";
  * const { client, hostContext, initialized, error } = useMcpAppsHostContext();
  */
 export function useMcpAppsHostContext(targetWindow?: Window) {
-  const client = useMemo(() => new McpAppsClient(targetWindow), [targetWindow]);
+  const client = useMemo(
+    () => McpAppsClient.getShared(targetWindow),
+    [targetWindow]
+  );
   const [hostContext, setHostContext] = useState<HostContext | undefined>();
   const [initialized, setInitialized] = useState(false);
   const [error, setError] = useState<Error | null>(null);

--- a/js/src/hooks/useMcpAppsHostContext.ts
+++ b/js/src/hooks/useMcpAppsHostContext.ts
@@ -1,0 +1,35 @@
+import { useEffect, useMemo, useState } from "react";
+import { HostContext, McpAppsClient } from "../mcp/appsClient";
+
+/**
+ * Hook to initialize MCP Apps client and expose hostContext.
+ *
+ * Usage:
+ * const { client, hostContext, initialized, error } = useMcpAppsHostContext();
+ */
+export function useMcpAppsHostContext(targetWindow?: Window) {
+  const client = useMemo(() => new McpAppsClient(targetWindow), [targetWindow]);
+  const [hostContext, setHostContext] = useState<HostContext | undefined>();
+  const [initialized, setInitialized] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    client.connect();
+
+    client
+      .initialize()
+      .then((res) => {
+        setHostContext(res.hostContext);
+        setInitialized(true);
+      })
+      .catch((e) => {
+        setError(e);
+      });
+
+    return () => {
+      client.disconnect();
+    };
+  }, [client]);
+
+  return { client, hostContext, initialized, error };
+}

--- a/js/src/hooks/useMcpAppsToolInput.ts
+++ b/js/src/hooks/useMcpAppsToolInput.ts
@@ -6,13 +6,16 @@ import { McpAppsClient } from "../mcp/appsClient";
  * Returns the latest params of `ui/notifications/tool-input`.
  */
 export function useMcpAppsToolInput(targetWindow?: Window) {
-  const client = useMemo(() => new McpAppsClient(targetWindow), [targetWindow]);
+  const client = useMemo(
+    () => McpAppsClient.getShared(targetWindow),
+    [targetWindow]
+  );
   const [toolInput, setToolInput] = useState<any>(() => client.getLatestToolInput());
 
   useEffect(() => {
     client.connect();
-    client.initialize().catch(() => {
-      /* ignore init errors for now */
+    client.initialize().catch((e) => {
+      console.warn("MCP Apps initialize failed", e);
     });
 
     const handleInput = (params: any) => {
@@ -31,5 +34,5 @@ export function useMcpAppsToolInput(targetWindow?: Window) {
     };
   }, [client]);
 
-  return toolInput;
+  return toolInput ?? null;
 }

--- a/js/src/hooks/useMcpAppsToolInput.ts
+++ b/js/src/hooks/useMcpAppsToolInput.ts
@@ -1,0 +1,35 @@
+import { useEffect, useMemo, useState } from "react";
+import { McpAppsClient } from "../mcp/appsClient";
+
+/**
+ * Subscribe to MCP Apps tool-input notifications.
+ * Returns the latest params of `ui/notifications/tool-input`.
+ */
+export function useMcpAppsToolInput(targetWindow?: Window) {
+  const client = useMemo(() => new McpAppsClient(targetWindow), [targetWindow]);
+  const [toolInput, setToolInput] = useState<any>(() => client.getLatestToolInput());
+
+  useEffect(() => {
+    client.connect();
+    client.initialize().catch(() => {
+      /* ignore init errors for now */
+    });
+
+    const handleInput = (params: any) => {
+      setToolInput(params);
+    };
+
+    client.onToolInput(handleInput);
+
+    const latest = client.getLatestToolInput();
+    if (latest) {
+      setToolInput(latest);
+    }
+
+    return () => {
+      client.disconnect();
+    };
+  }, [client]);
+
+  return toolInput;
+}

--- a/js/src/hooks/useMcpAppsToolResult.ts
+++ b/js/src/hooks/useMcpAppsToolResult.ts
@@ -6,14 +6,17 @@ import { McpAppsClient } from "../mcp/appsClient";
  * Returns the latest params of `ui/notifications/tool-result`.
  */
 export function useMcpAppsToolResult(targetWindow?: Window) {
-  const client = useMemo(() => new McpAppsClient(targetWindow), [targetWindow]);
+  const client = useMemo(
+    () => McpAppsClient.getShared(targetWindow),
+    [targetWindow]
+  );
   const [result, setResult] = useState<any>(() => client.getLatestToolResult());
 
   useEffect(() => {
     client.connect();
     // Initialize handshake so host starts sending notifications
-    client.initialize().catch(() => {
-      /* ignore init errors for now */
+    client.initialize().catch((e) => {
+      console.warn("MCP Apps initialize failed", e);
     });
 
     const handleResult = (params: any) => {
@@ -33,5 +36,5 @@ export function useMcpAppsToolResult(targetWindow?: Window) {
     };
   }, [client]);
 
-  return result;
+  return result ?? null;
 }

--- a/js/src/hooks/useMcpAppsToolResult.ts
+++ b/js/src/hooks/useMcpAppsToolResult.ts
@@ -1,0 +1,37 @@
+import { useEffect, useMemo, useState } from "react";
+import { McpAppsClient } from "../mcp/appsClient";
+
+/**
+ * Subscribe to MCP Apps tool-result notifications.
+ * Returns the latest params of `ui/notifications/tool-result`.
+ */
+export function useMcpAppsToolResult(targetWindow?: Window) {
+  const client = useMemo(() => new McpAppsClient(targetWindow), [targetWindow]);
+  const [result, setResult] = useState<any>(() => client.getLatestToolResult());
+
+  useEffect(() => {
+    client.connect();
+    // Initialize handshake so host starts sending notifications
+    client.initialize().catch(() => {
+      /* ignore init errors for now */
+    });
+
+    const handleResult = (params: any) => {
+      setResult(params);
+    };
+
+    client.onToolResult(handleResult);
+
+    // Prime state if host already sent one before handler
+    const latest = client.getLatestToolResult();
+    if (latest) {
+      setResult(latest);
+    }
+
+    return () => {
+      client.disconnect();
+    };
+  }, [client]);
+
+  return result;
+}

--- a/js/src/hooks/useWidgetData.ts
+++ b/js/src/hooks/useWidgetData.ts
@@ -1,0 +1,40 @@
+import { useMemo } from "react";
+import { useWidgetProps } from "./useWidgetProps";
+import { useMcpAppsToolResult } from "./useMcpAppsToolResult";
+
+type Options<T> = {
+  /**
+    * Optional fallback if neither OpenAI toolOutput nor MCP Apps tool-result
+    * is available yet.
+    */
+  defaultValue?: T | (() => T);
+};
+
+/**
+ * Protocol-agnostic widget data hook.
+ *
+ * - If window.openai.toolOutput exists (OpenAI Apps), return it.
+ * - Otherwise, subscribe to MCP Apps ui/notifications/tool-result and return structuredContent.
+ */
+export function useWidgetData<T = any>(options?: Options<T>): T | null {
+  // OpenAI Apps path
+  const openaiProps = useWidgetProps<T>();
+
+  // MCP Apps path
+  const mcpResult = useMcpAppsToolResult();
+  const mcpData = mcpResult?.structuredContent ?? null;
+
+  // Choose OpenAI first if available, else MCP, else default
+  return useMemo(() => {
+    if (openaiProps != null) return openaiProps;
+    if (mcpData != null) return mcpData as T;
+
+    const { defaultValue } = options ?? {};
+    if (defaultValue !== undefined) {
+      return typeof defaultValue === "function"
+        ? (defaultValue as () => T)()
+        : defaultValue;
+    }
+    return null;
+  }, [openaiProps, mcpData, options]);
+}

--- a/js/src/hooks/useWidgetData.ts
+++ b/js/src/hooks/useWidgetData.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useWidgetProps } from "./useWidgetProps";
 import { useMcpAppsToolResult } from "./useMcpAppsToolResult";
+import type { UnknownObject } from "./types";
 
 type Options<T> = {
   /**
@@ -16,12 +17,9 @@ type Options<T> = {
  * - If window.openai.toolOutput exists (OpenAI Apps), return it.
  * - Otherwise, subscribe to MCP Apps ui/notifications/tool-result and return structuredContent.
  */
-export function useWidgetData<T = any>(options?: Options<T>): T | null {
-  const protocolHint =
-    typeof window !== "undefined"
-      ? (window as any).__FASTAPPS_PROTOCOL
-      : undefined;
-
+export function useWidgetData<T extends UnknownObject = UnknownObject>(
+  options?: Options<T>
+): T | null {
   // OpenAI Apps path
   const openaiProps = useWidgetProps<T>();
 
@@ -31,13 +29,6 @@ export function useWidgetData<T = any>(options?: Options<T>): T | null {
 
   // Choose OpenAI first if available, else MCP, else default
   return useMemo(() => {
-    if (protocolHint === "openai-apps") {
-      return openaiProps ?? null;
-    }
-    if (protocolHint === "mcp-apps") {
-      return (mcpData as T) ?? null;
-    }
-
     if (openaiProps != null) return openaiProps;
     if (mcpData != null) return mcpData as T;
 

--- a/js/src/hooks/useWidgetData.ts
+++ b/js/src/hooks/useWidgetData.ts
@@ -17,6 +17,11 @@ type Options<T> = {
  * - Otherwise, subscribe to MCP Apps ui/notifications/tool-result and return structuredContent.
  */
 export function useWidgetData<T = any>(options?: Options<T>): T | null {
+  const protocolHint =
+    typeof window !== "undefined"
+      ? (window as any).__FASTAPPS_PROTOCOL
+      : undefined;
+
   // OpenAI Apps path
   const openaiProps = useWidgetProps<T>();
 
@@ -26,6 +31,13 @@ export function useWidgetData<T = any>(options?: Options<T>): T | null {
 
   // Choose OpenAI first if available, else MCP, else default
   return useMemo(() => {
+    if (protocolHint === "openai-apps") {
+      return openaiProps ?? null;
+    }
+    if (protocolHint === "mcp-apps") {
+      return (mcpData as T) ?? null;
+    }
+
     if (openaiProps != null) return openaiProps;
     if (mcpData != null) return mcpData as T;
 

--- a/js/src/hooks/useWidgetProps.ts
+++ b/js/src/hooks/useWidgetProps.ts
@@ -1,4 +1,4 @@
-import { useOpenAiGlobal } from "./useOpenAiGlobal";
+import { useOpenAiGlobal } from "./useOpenaiGlobal";
 
 /**
  * Hook to get widget props from ChatGPT tool output.
@@ -28,4 +28,3 @@ export function useWidgetProps<T extends Record<string, unknown>>(
 
   return props ?? fallback;
 }
-

--- a/js/src/hooks/useWidgetState.ts
+++ b/js/src/hooks/useWidgetState.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, type SetStateAction } from "react";
-import { useOpenAiGlobal } from "./useOpenAiGlobal";
+import { useOpenAiGlobal } from "./useOpenaiGlobal";
 import type { UnknownObject } from "./types";
 
 /**
@@ -67,4 +67,3 @@ export function useWidgetState<T extends UnknownObject>(
 
   return [widgetState, setWidgetState] as const;
 }
-

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-export { useOpenAiGlobal } from './hooks/useOpenAiGlobal';
+export { useOpenAiGlobal } from './hooks/useOpenaiGlobal';
 export { useWidgetProps } from './hooks/useWidgetProps';
 export { useWidgetState } from './hooks/useWidgetState';
 export { useDisplayMode } from './hooks/useDisplayMode';

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -12,6 +12,9 @@ export { useMaxHeight } from './hooks/useMaxHeight';
 export { useMcpAppsHostContext } from './hooks/useMcpAppsHostContext';
 export { useMcpAppsToolResult } from './hooks/useMcpAppsToolResult';
 export { useMcpAppsToolInput } from './hooks/useMcpAppsToolInput';
+export { useWidgetData } from './hooks/useWidgetData';
+export { useHostContextCompat } from './hooks/useHostContextCompat';
+export { useHostActions } from './hooks/useHostActions';
 export { McpAppsClient } from './mcp/appsClient';
 
 export type {

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -10,6 +10,8 @@ export { useWidgetState } from './hooks/useWidgetState';
 export { useDisplayMode } from './hooks/useDisplayMode';
 export { useMaxHeight } from './hooks/useMaxHeight';
 export { useMcpAppsHostContext } from './hooks/useMcpAppsHostContext';
+export { useMcpAppsToolResult } from './hooks/useMcpAppsToolResult';
+export { useMcpAppsToolInput } from './hooks/useMcpAppsToolInput';
 export { McpAppsClient } from './mcp/appsClient';
 
 export type {

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -9,6 +9,8 @@ export { useWidgetProps } from './hooks/useWidgetProps';
 export { useWidgetState } from './hooks/useWidgetState';
 export { useDisplayMode } from './hooks/useDisplayMode';
 export { useMaxHeight } from './hooks/useMaxHeight';
+export { useMcpAppsHostContext } from './hooks/useMcpAppsHostContext';
+export { McpAppsClient } from './mcp/appsClient';
 
 export type {
   OpenAiGlobals,
@@ -22,3 +24,4 @@ export type {
   CallToolResponse,
 } from './hooks/types';
 
+export type { HostContext, UiInitializeResult } from './mcp/appsClient';

--- a/js/src/mcp/appsClient.ts
+++ b/js/src/mcp/appsClient.ts
@@ -73,7 +73,6 @@ export class McpAppsClient {
   private nextId: number;
   private pending: Map<number, Pending>;
   private notificationHandlers: Map<string, ((params: any) => void)[]>;
-  private initialized = false;
   private latestToolResult: any = null;
   private latestToolInput: any = null;
   private toolResultListeners: ((result: any) => void)[] = [];
@@ -103,7 +102,6 @@ export class McpAppsClient {
       clientInfo: { name: "fastapps-ui", version: "1.0.0" },
       protocolVersion: "2025-06-18",
     });
-    this.initialized = true;
     return result as UiInitializeResult;
   }
 

--- a/js/src/mcp/appsClient.ts
+++ b/js/src/mcp/appsClient.ts
@@ -1,0 +1,169 @@
+/**
+ * Minimal MCP Apps (SEP-1865 draft) postMessage client for UI iframes.
+ *
+ * The UI (guest) sends JSON-RPC 2.0 messages to its parent host.
+ * This client handles ui/initialize handshake and generic request/notification flows.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export type JsonRpcId = number;
+
+export type JsonRpcRequest = {
+  jsonrpc: "2.0";
+  id: JsonRpcId;
+  method: string;
+  params?: any;
+};
+
+export type JsonRpcResponse =
+  | {
+      jsonrpc: "2.0";
+      id: JsonRpcId;
+      result: any;
+    }
+  | {
+      jsonrpc: "2.0";
+      id: JsonRpcId;
+      error: { code: number; message: string; data?: any };
+    };
+
+export type JsonRpcNotification = {
+  jsonrpc: "2.0";
+  method: string;
+  params?: any;
+};
+
+export type HostContext = {
+  toolInfo?: {
+    id?: string | number;
+    tool?: any;
+  };
+  theme?: "light" | "dark" | "system";
+  displayMode?: "inline" | "fullscreen" | "pip" | "carousel";
+  availableDisplayModes?: string[];
+  viewport?: {
+    width: number;
+    height: number;
+    maxHeight?: number;
+    maxWidth?: number;
+  };
+  locale?: string;
+  timeZone?: string;
+  userAgent?: string;
+  platform?: "web" | "desktop" | "mobile";
+  deviceCapabilities?: { touch?: boolean; hover?: boolean };
+  safeAreaInsets?: { top: number; right: number; bottom: number; left: number };
+};
+
+export type UiInitializeResult = {
+  protocolVersion: string;
+  hostCapabilities?: any;
+  hostInfo?: { name: string; version: string };
+  hostContext?: HostContext;
+};
+
+type Pending = {
+  resolve: (value: any) => void;
+  reject: (error: Error) => void;
+};
+
+export class McpAppsClient {
+  private target: Window;
+  private nextId: number;
+  private pending: Map<number, Pending>;
+  private notificationHandlers: Map<string, ((params: any) => void)[]>;
+  private initialized = false;
+
+  constructor(targetWindow?: Window) {
+    this.target = targetWindow ?? window.parent;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.notificationHandlers = new Map();
+    this.handleMessage = this.handleMessage.bind(this);
+  }
+
+  connect() {
+    window.addEventListener("message", this.handleMessage);
+  }
+
+  disconnect() {
+    window.removeEventListener("message", this.handleMessage);
+    this.pending.clear();
+    this.notificationHandlers.clear();
+  }
+
+  async initialize(): Promise<UiInitializeResult> {
+    const result = await this.sendRequest("ui/initialize", {
+      capabilities: {},
+      clientInfo: { name: "fastapps-ui", version: "1.0.0" },
+      protocolVersion: "2025-06-18",
+    });
+    this.initialized = true;
+    return result as UiInitializeResult;
+  }
+
+  async sendRequest(method: string, params?: any): Promise<any> {
+    const id = this.nextId++;
+    const message: JsonRpcRequest = {
+      jsonrpc: "2.0",
+      id,
+      method,
+      params,
+    };
+
+    const promise = new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      try {
+        this.target.postMessage(message, "*");
+      } catch (e: any) {
+        this.pending.delete(id);
+        reject(e);
+      }
+    });
+
+    return promise;
+  }
+
+  sendNotification(method: string, params?: any) {
+    const message: JsonRpcNotification = {
+      jsonrpc: "2.0",
+      method,
+      params,
+    };
+    this.target.postMessage(message, "*");
+  }
+
+  onNotification(method: string, handler: (params: any) => void) {
+    const handlers = this.notificationHandlers.get(method) ?? [];
+    handlers.push(handler);
+    this.notificationHandlers.set(method, handlers);
+  }
+
+  private handleMessage(event: MessageEvent) {
+    const data = event.data as JsonRpcResponse | JsonRpcNotification;
+    if (!data || data.jsonrpc !== "2.0") {
+      return;
+    }
+
+    // Response
+    if ("id" in data && (data as any).id !== undefined) {
+      const pending = this.pending.get((data as any).id);
+      if (!pending) return;
+      this.pending.delete((data as any).id);
+
+      if ("result" in data) {
+        pending.resolve((data as any).result);
+      } else if ("error" in data) {
+        pending.reject(new Error((data as any).error?.message ?? "Unknown error"));
+      }
+      return;
+    }
+
+    // Notification
+    if ("method" in data) {
+      const handlers = this.notificationHandlers.get((data as any).method) ?? [];
+      handlers.forEach((fn) => fn((data as any).params));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Add a protocol adapter layer to serve MCP Apps (SEP-1865) alongside OpenAI Apps, with protocol-aware UI hints and shared MCP client hooks.

## Context
[SEP-1865 (MCP Apps)](https://blog.modelcontextprotocol.io/posts/2025-11-21-mcp-apps/) is a draft MCP extension being developed collaboratively by Anthropic, OpenAI, and the MCP-UI community to unify how MCP servers deliver interactive UIs to host applications.

Currently, different implementations exist with varying conventions:
- **OpenAI Apps SDK** — enables interactive apps inside ChatGPT using MCP
- **MCP-UI** — community project for rich UI as MCP resources

SEP-1865 aims to standardize these patterns (`text/html+mcp` MIME type, `ui://` URIs, JSON-RPC over postMessage) so servers can work consistently across any compliant host. This PR prepares FastApps for that future while maintaining full compatibility with the existing OpenAI Apps SDK.

This implementation references the [ext-apps repository](https://github.com/modelcontextprotocol/ext-apps), which contains the draft specification and reference SDK examples.

## Breaking changes
None. Default adapter remains OpenAI; MCP is opt-in via the auto adapter or explicit selection.

## Code changes

### Protocol Adapter Layer (`fastapps/core/adapters/`)

**What**: `ProtocolAdapter` abstract interface with three implementations:
- `OpenAIAppsAdapter` — existing OpenAI Apps SDK behavior (default)
- `MCPAppsAdapter` — SEP-1865 compliant responses (`text/html+mcp`, `ui://` URIs)
- `AutoProtocolAdapter` — runtime selection based on client capabilities

**Why**: Decouples protocol-specific response formatting from core widget logic. Adding future protocols (or modifying existing ones) won't require changes to `WidgetMCPServer` internals. Auto adapter inspects `initialize.extensions["io.modelcontextprotocol/ui"].mimeTypes` for `text/html+mcp` to switch protocols without manual configuration.

### Shared call_tool Helper (`fastapps/core/adapters/utils.py`)

**What**: Extracted `_execute_widget_call()` that handles auth inheritance, scope validation, locale negotiation, input validation, and widget execution.

**Why**: Both adapters had ~80 lines of identical auth/validation logic. Single source of truth prevents drift and simplifies maintenance.

### Protocol Hint Injection

**What**: `_inject_protocol_hint()` embeds `<script>window.__FASTAPPS_PROTOCOL="openai-apps"|"mcp-apps"</script>` into HTML before `</head>`.

**Why**: The iframe needs to know which communication path to use (OpenAI globals vs MCP postMessage). Relying solely on host-injected globals is fragile; server-driven hint keeps BE/FE in sync and works regardless of host implementation details.

### CLI Protocol Selection (`fastapps/cli/`)

**What**: Added `--protocol` flag to `fastapps dev` command with options: `openai-apps` (default), `mcp-apps`, `auto`.

**Why**: Allows developers to explicitly test against a specific protocol during development, or use `auto` to let the host's capabilities determine the protocol at runtime.

### MCP Apps Client (`js/src/mcp/appsClient.ts`)

**What**: JSON-RPC 2.0 client for postMessage communication with MCP hosts. Features:
- `McpAppsClient.getShared()` — singleton per window via WeakMap
- Reference-counted `connect()`/`disconnect()`
- Origin safety via `document.referrer` fallback (not hardcoded `"*"`)
- Typed notification handlers for `ui/notifications/tool-result` and `tool-input`

**Why**: Multiple hooks need the same client; creating instances per hook wastes resources and causes duplicate message handlers. Reference counting ensures cleanup only when all consumers disconnect. Origin from referrer provides reasonable security without requiring manual configuration.

### Protocol-Agnostic Hooks (`js/src/hooks/`)

**What**: 
- `useWidgetData()` — returns OpenAI `toolOutput` or MCP `structuredContent`, whichever is available
- `useHostContextCompat()` — merges OpenAI globals and MCP `hostContext` into unified shape
- `useHostActions()` — `openLink`, `sendMessage`, `callTool`, `requestDisplayMode` that route to OpenAI or MCP APIs based on protocol hint

**Why**: Widget code shouldn't branch on protocol. These hooks abstract the difference so templates work unchanged on either host type.

### Template Updates

**What**: Built-in templates (`albums`, `carousel`, `list`, `default`) now use `useWidgetData()` instead of `useWidgetProps()`. Albums template routes display mode changes through `useHostActions().requestDisplayMode()`.

**Why**: Demonstrates the protocol-agnostic pattern and ensures bundled templates work on both OpenAI and MCP hosts out of the box.

## Testing
- **OpenAI Apps**: tested in OpenAI dev mode — OK.
- **MCP Apps (SEP-1865)**: not tested — no compliant host available yet. The reference MCP-UI client is still being updated to align with SEP-1865 (PR open). Adapter logic and hint injection are in place; end-to-end validation pending a compliant host.